### PR TITLE
fix for "AttributeError: 'Request' object has no attribute 'get'"

### DIFF
--- a/jinja2_sanic/__init__.py
+++ b/jinja2_sanic/__init__.py
@@ -1,4 +1,3 @@
-from sanic import Sanic
 from sanic.exceptions import ServerError
 from sanic.response import HTTPResponse
 from sanic.views import HTTPMethodView
@@ -95,8 +94,10 @@ def render_string(template_name, request, context, *, app_key=APP_KEY):
             "context should be mapping, not {}".format(type(context)),
             status_code=500,
         )
-    if request.get(REQUEST_CONTEXT_KEY):
-        context = dict(request[REQUEST_CONTEXT_KEY], **context)
+    try:
+        context = dict(request.ctx.__dict__[REQUEST_CONTEXT_KEY], **context)
+    except KeyError:
+        pass
     text = template.render(context)
     return text
 


### PR DESCRIPTION
Fixes this error with Python 3.8:

```
2020-05-31 14:30:43 +0200] [34495] [INFO] Goin' Fast @ http://127.0.0.1:8080
[2020-05-31 14:30:43 +0200] [34495] [INFO] Starting worker [34495]
[2020-05-31 14:30:57 +0200] [34495] [ERROR] Exception occurred while handling uri: 'http://127.0.0.1:8080/'
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/sanic/app.py", line 973, in handle_request
    response = await response
  File "/usr/local/lib/python3.8/dist-packages/jinja2_sanic/__init__.py", line 164, in wrapped
    return render_template(template_name, request, context,
  File "/usr/local/lib/python3.8/dist-packages/jinja2_sanic/__init__.py", line 122, in render_template
    text = render_string(template_name, request, context, app_key=app_key)
  File "/usr/local/lib/python3.8/dist-packages/jinja2_sanic/__init__.py", line 98, in render_string
    if request.get(REQUEST_CONTEXT_KEY):
AttributeError: 'Request' object has no attribute 'get'
[2020-05-31 14:30:57 +0200] - (sanic.access)[INFO][127.0.0.1:45762]: GET http://127.0.0.1:8080/  500 250
[2020-05-31 14:30:57 +0200] - (sanic.access)[INFO][127.0.0.1:45762]: GET http://127.0.0.1:8080/favicon.ico  404 188
^C[2020-05-31 14:40:32 +0200] [34495] [INFO] Stopping worker [34495]
```

as of now sanic.request.Request has no method get(). only get_args().
but we can access ctx directly. [as seen here](https://github.com/huge-success/sanic/blob/master/sanic/request.py#L90)
then making it a dict and accessing the key seems to work fine

also the import ```from sanic import Sanic``` was unused.
